### PR TITLE
Collapse fields also when in data

### DIFF
--- a/bukget/api.py
+++ b/bukget/api.py
@@ -29,7 +29,7 @@ def _request(url, data=None, jsonify=True, headers={}, query={}):
     if 'fields' in query and (' ' in query['fields'] or\
                               isinstance(query['fields'], list)):
         query['fields'] = ','.join(query['fields'])
-    if 'fields' in data and (' ' in data['fields'] or\
+    if data is not None and 'fields' in data and (' ' in data['fields'] or\
                               isinstance(data['fields'], list)):
         data['fields'] = ','.join(data['fields'])
 


### PR DESCRIPTION
This commit collapses the fields to a comma separated string when they are placed in data, in addition to when they are placed in query. This fixes an issue which makes searching through the ORM impossible. To recreate this issue, you can try this:

```
bukget.orm.search({'field':'slug','action':'=','value':'backpacks'})
```

which won't work, and then

```
bukget.api.search({'field':'slug','action':'=','value':'backpacks'})
```

which will work. 

I've traced this issue to be the missing collapsing of  lists to comma separated strings when the fields are in the data, and not the query object.
