### PR TITLE
Fix NameError (variables not defined), 2 instances.

### DIFF
--- a/bukget.py
+++ b/bukget.py
@@ -116,9 +116,9 @@ def category_plugins(category, server=None, **query):
     # Depending on if the server variable is set, we can have one of 2
     # different URLs, so here we will set the call to the correct one.
     if server is not None:
-        call = '/categories/%s/%s' % (server, author)
+        call = '/categories/%s/%s' % (server, category)
     else:
-        call = '/categories/%s' % name
+        call = '/categories/%s' % category
     return _request(call, query=query)
 
 


### PR DESCRIPTION
bukget.category_plugins() refers to two variables that are not defined.  Looks like a cut and paste error.  This pull changes them to refer to the parameter 'category'.

Test code:
    >>> import bukget
    >>> bukget.category_plugins('World Generators')[0]
    {u'description': u'', u'plugin_name': u'AncientCave', u'slug': u'acientcave'}
